### PR TITLE
Add support for arm64 builds to the example

### DIFF
--- a/example/Makefile
+++ b/example/Makefile
@@ -1,8 +1,16 @@
 prog := python-enclave
-version := $(shell git describe --tag --dirty)
+version := $(shell git describe --tag --dirty --always)
 image_tag := $(prog):$(version)
 image_tar := $(prog)-$(version)-kaniko.tar
 image_eif := $(image_tar:%.tar=%.eif)
+
+ARCH ?= $(shell uname -m)
+ifeq ($(ARCH),aarch64)
+	override ARCH=arm64
+endif
+ifeq ($(ARCH),x86_64)
+	override ARCH=amd64
+endif
 
 .PHONY: all
 all: run
@@ -18,7 +26,7 @@ $(image_tar): Dockerfile service.py start.sh
 		--no-push \
 		--tarPath $(image_tar) \
 		--destination $(image_tag) \
-		--custom-platform linux/amd64
+		--custom-platform linux/$(ARCH)
 
 $(image_eif): $(image_tar)
 	docker load -i $<


### PR DESCRIPTION
Rather than forcing the nitriding example to build against the amd64 architecture, update the example to automatically choose the build architecture based on the architecture of the machine where the example is built and run.