### PR TITLE
Replace pkill with kill in example script

### DIFF
--- a/example/run-enclave.sh
+++ b/example/run-enclave.sh
@@ -27,4 +27,4 @@ nitro-cli run-enclave \
 	--attach-console
 
 echo "[ec2] Stopping gvproxy."
-sudo pkill -INT -P "$pid"
+sudo kill -INT "$pid"


### PR DESCRIPTION
Replace `pkill` with `kill` as `pkill` is unnecessary and not always available.